### PR TITLE
fix: changing the pydantic BaseSecret model value metadata to secretMetadata

### DIFF
--- a/infisical_sdk/api_types.py
+++ b/infisical_sdk/api_types.py
@@ -73,7 +73,7 @@ class BaseSecret(BaseModel):
     secretReminderNote: Optional[str] = None
     secretReminderRepeatDays: Optional[int] = None
     skipMultilineEncoding: Optional[bool] = False
-    metadata: Optional[Any] = None
+    secretMetadata: Optional[Any] = None
     secretPath: Optional[str] = None
     tags: List[SecretTag] = field(default_factory=list)
 

--- a/infisical_sdk/api_types.py
+++ b/infisical_sdk/api_types.py
@@ -55,6 +55,11 @@ class SecretTag(BaseModel):
     name: str
     color: Optional[str] = None
 
+@dataclass
+class SecretMetadata(BaseModel):
+    """Model for secret metadata"""
+    key: str
+    value: str
 
 @dataclass
 class BaseSecret(BaseModel):
@@ -73,7 +78,8 @@ class BaseSecret(BaseModel):
     secretReminderNote: Optional[str] = None
     secretReminderRepeatDays: Optional[int] = None
     skipMultilineEncoding: Optional[bool] = False
-    secretMetadata: Optional[Any] = None
+    metadata: Optional[Any] = None
+    secretMetadata: List[SecretMetadata] = field(default_factory=list)
     secretPath: Optional[str] = None
     tags: List[SecretTag] = field(default_factory=list)
 


### PR DESCRIPTION
The sdk is currently throwing a Type error when trying to call `list_secrets` or `get_secret_by_name`.

`TypeError: BaseSecret.__init__() got an unexpected keyword argument 'secretMetadata'`.

It also throws an APIError when trying to call `create_secret_by_name` or `update_secret_by_name`.

`raise APIError(
infisical_sdk.infisical_requests.APIError: [{'code': 'invalid_type', 'expected': 'string', 'received': 'undefined', 'path': ['secretValue'], 'message': 'Required'}] (Status: 422)`

This change fixes the error.