### PR TITLE
fix: strict schema crash

### DIFF
--- a/infisical_sdk/api_types.py
+++ b/infisical_sdk/api_types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Optional, List, Any, Dict
 from enum import Enum
 import json
@@ -34,7 +34,10 @@ class BaseModel:
     @classmethod
     def from_dict(cls, data: Dict) -> 'BaseModel':
         """Create model from dictionary"""
-        return cls(**data)
+        # Get only the fields that exist in the dataclass
+        valid_fields = {f.name for f in fields(cls)}
+        filtered_data = {k: v for k, v in data.items() if k in valid_fields}
+        return cls(**filtered_data)
 
     def to_json(self) -> str:
         """Convert model to JSON string"""
@@ -70,6 +73,7 @@ class BaseSecret(BaseModel):
     secretComment: str
     createdAt: str
     updatedAt: str
+    secretMetadata: Optional[Dict[str, Any]] = None
     secretReminderNote: Optional[str] = None
     secretReminderRepeatDays: Optional[int] = None
     skipMultilineEncoding: Optional[bool] = False


### PR DESCRIPTION
This PR resolves #15 which caused the SDK to start failing after the new `secretMetadata` field was added to the API response. The issue is that our SDK is too strict, and will error if the response doesn't exactly match the schema defined in the Python SDK.

We are now filtering the fields before usage.