### PR TITLE
fix: update required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages  # noqa: H301
 # http://pypi.python.org/pypi/setuptools
 NAME = "infisicalsdk"
 VERSION = "1.0.1"
-PYTHON_REQUIRES = ">=3.7"
+PYTHON_REQUIRES = ">=3.8"
 REQUIRES = [
     "urllib3 >= 1.25.3, < 2.1.0",
     "python-dateutil",


### PR DESCRIPTION
The SDK does not work on Python 3.7, only 3.8 and above due to our `requests` dependency. Mentioned in #10 