### PR TITLE
fix: not subscribable error (python version <=3.8)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/infisical_sdk/infisical_requests.py
+++ b/infisical_sdk/infisical_requests.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generic, Optional, TypeVar
+from typing import Any, Dict, Generic, Optional, TypeVar, Type
 from urllib.parse import urljoin
 import requests
 from dataclasses import dataclass
@@ -90,7 +90,7 @@ class InfisicalRequests:
     def get(
             self,
             path: str,
-            model: type[T],
+            model: Type[T],
             params: Optional[Dict[str, Any]] = None
           ) -> APIResponse[T]:
 
@@ -116,7 +116,7 @@ class InfisicalRequests:
     def post(
             self,
             path: str,
-            model: type[T],
+            model: Type[T],
             json: Optional[Dict[str, Any]] = None
           ) -> APIResponse[T]:
 
@@ -140,7 +140,7 @@ class InfisicalRequests:
     def patch(
             self,
             path: str,
-            model: type[T],
+            model: Type[T],
             json: Optional[Dict[str, Any]] = None
           ) -> APIResponse[T]:
 
@@ -164,7 +164,7 @@ class InfisicalRequests:
     def delete(
             self,
             path: str,
-            model: type[T],
+            model: Type[T],
             json: Optional[Dict[str, Any]] = None
           ) -> APIResponse[T]:
 


### PR DESCRIPTION
This PR resolves the `not subscribable` error encountered on Python version 3.8 or lower. In Python 3.9 a global `type` was introduced, which we were using in the SDK. For Python 3.9, we need to manually import `Type` from typing, which works in the exact same way.

Python 3.8 recently reached EOL, but we are resolving this issue to support a wider range of Python versions, as many companies still depend on 3.8 today.